### PR TITLE
Update touch-0.2.14.js

### DIFF
--- a/touch-0.2.14.js
+++ b/touch-0.2.14.js
@@ -241,6 +241,10 @@ var engine = {
                 utils.forceReflow();
             }
             e.originEvent = e;
+            
+            // 被绑定的dom对象
+            e.bindTarget = el;
+            
             for (var p in e.detail) {
                 if (p !== 'type') {
                     e[p] = e.detail[p];


### PR DESCRIPTION
在某些场景下需要获取被绑定的那个dom对象来使用，所以在customEvent中返回被绑定事件的那个dom对象
