### PR TITLE
修改获取元素位置的方式

### DIFF
--- a/touch-0.2.14.js
+++ b/touch-0.2.14.js
@@ -131,25 +131,30 @@ utils.getDirectionFromAngle = function(agl) {
 };
 
 utils.getXYByElement = function(el) {
+    var boundingBox;
     var left = 0,
         top = 0;
 
-    while (el.offsetParent) {
-        left += el.offsetLeft;
-        top += el.offsetTop;
-        el = el.offsetParent;
-    }
+    boundingBox = el.getBoundingClientRect();
+    left = window.pageXOffset + boundingBox.left;
+    top = window.pageYOffset + boundingBox.top;
+
     return {
-        left: left,
-        top: top
+        "left": left,
+        "top": top
     };
 };
 
 utils.reset = function() {
     startEvent = moveEvent = endEvent = null;
-    __tapped = __touchStart = startSwiping = startPinch = false;
-    startDrag = false;
-    pos = {};
+    __tapped = __touchStart = startSwiping = startPinch = startDrag = false;
+
+    pos = {
+        start: null,
+        move: null,
+        end: null
+    };
+
     __rotation_single_finger = false;
 };
 
@@ -744,7 +749,10 @@ var handlerOriginEvent = function(ev) {
         case 'touchmove':
         case 'mousemove':
             if (!__touchStart || !pos.start) return;
+
+            moveEvent = ev;
             pos.move = utils.getPosOfEvent(ev);
+
             if (utils.getFingers(ev) >= 2) {
                 gestures.pinch(ev);
             } else if (__rotation_single_finger) {
@@ -758,6 +766,7 @@ var handlerOriginEvent = function(ev) {
         case 'mouseup':
         case 'mouseout':
             if (!__touchStart) return;
+
             endEvent = ev;
 
             if (startPinch) {


### PR DESCRIPTION
将原来通过 offsetParent 进行迭代以求得元素位置的算法改变为，由 window
对象的pageXOffset（纵向是pageYOffset）加上元素 boundingClientRect.left（纵向为 top）。
